### PR TITLE
Use setState to store a permanent wrapperFunction

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,25 @@ import React, { useState } from "react";
 import Form from "./Form";
 import "./App.css";
 
+// This needs to return the same function every time it is called, but that one
+// unchanging function should call the last `fn` that was passed to this.
+function useWrapperFunction(fn) {
+  // The key here is that state will be the same object every time, so we can
+  // just return the `wrapperFunction` that was created on the first render.
+  const [ state ] = useState({
+    wrapperFunction(...args) { return state.fn.apply(this, args)},
+    fn
+  })
+
+  // Normally you don't mutate state in React. I think it's worth it here and
+  // has little risk because this is all self-contained in this function.
+  state.fn = fn
+
+  // Since we just return a property, `state` never leaves this function (except
+  // to be stored by Reac
+  return state.wrapperFunction
+}
+
 export default () => {
   const [todos, setTodos] = useState([]);
 
@@ -19,10 +38,12 @@ export default () => {
       )
     );
 
+  const onSubmit = useWrapperFunction(text => setTodos([{ text, complete: false }, ...todos]))
+
   return (
     <div className="App">
       <Form
-        onSubmit={text => setTodos([{ text, complete: false }, ...todos])}
+        onSubmit={onSubmit}
       />
       <div>
         {todos.map(({ text, complete }, i) => (

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -10,8 +10,10 @@ const useInputValue = initialValue => {
   };
 };
 
-export default ({ onSubmit }) => {
+export default React.memo(({ onSubmit }) => {
   const { resetValue, ...text } = useInputValue("");
+
+  console.log('<Form', Math.random())
 
   return (
     <form
@@ -24,4 +26,4 @@ export default ({ onSubmit }) => {
       <input {...text} />
     </form>
   );
-};
+});


### PR DESCRIPTION
I enjoyed your video and wanted to try finding other solutions. I figured a PR is the best way to show what I came up with.

I suspect some people won't like the idea of mutating state like this. So I have another version that [uses WeakMap()](https://github.com/AsaAyers/react-hooks-examples/blob/weak-map/src/App.js#L6) but operates on the same principal.